### PR TITLE
County and brewery-category discovery

### DIFF
--- a/app/breweries/category/[slug]/page.tsx
+++ b/app/breweries/category/[slug]/page.tsx
@@ -2,53 +2,72 @@ import React from 'react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Tag, Dog, Beer, Utensils, Factory, Trees } from 'lucide-react';
 import { contentService } from '@/lib/services/content.service';
 import { PageContainer } from '@/components/layout/page-container';
 import { BreweryCard } from '@/components/ui/brewery-card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Brewery } from '@/lib/types';
 
 interface CategoryPageProps {
   params: Promise<{ slug: string }>;
 }
 
-// Map slug to category name, matching either type or amenity
-import { Brewery } from '@/lib/types';
+export interface CategoryDefinition {
+  name: string;
+  badge: string;
+  title: string;
+  desc: string;
+  icon: React.ReactNode;
+  filterFn: (b: Brewery) => boolean;
+}
 
-const CATEGORY_MAP: Record<string, { name: string; title: string; desc: string; filterFn: (b: Brewery) => boolean }> = {
+export const CATEGORY_MAP: Record<string, CategoryDefinition> = {
   'dog-friendly': {
     name: 'Dog Friendly',
-    title: 'Dog Friendly Breweries in Maryland',
-    desc: 'Explore the best pet and dog-friendly breweries in Maryland. Sit outside with your pup, enjoy craft drinks, and relax in spacious outdoor beer gardens.',
-    filterFn: (b) => b.amenities.some((a: string) => a.toLowerCase().includes('dog friendly'))
+    badge: 'Amenity Category',
+    title: 'Dog-Friendly Breweries in Maryland',
+    desc: 'Explore pet- and dog-friendly breweries across Maryland. Enjoy craft drinks, bring your dog to outdoor beer gardens, and relax on patio seating.',
+    icon: <Dog className="w-4 h-4 text-amber-400" />,
+    filterFn: (b) => b.amenities.some((a: string) => a.toLowerCase().includes('dog friendly')),
   },
-  'microbrewery': {
+  microbrewery: {
     name: 'Microbrewery',
+    badge: 'Brewery Type',
     title: 'Local Microbreweries in Maryland',
-    desc: 'Discover microbreweries in Maryland. Taste local, small-batch, innovative craft beers brewed with passion by community-driven brewmasters.',
-    filterFn: (b) => b.type === 'Microbrewery'
+    desc: 'Discover independent microbreweries in Maryland. Taste local small-batch IPAs, stouts, and experimental craft brews brewed with community passion.',
+    icon: <Beer className="w-4 h-4 text-amber-400" />,
+    filterFn: (b) => b.type === 'Microbrewery',
   },
-  'brewpub': {
+  brewpub: {
     name: 'Brewpub',
-    title: 'Best Brewpubs in Maryland | Craft Beer & Dining',
-    desc: 'Browse prime craft beer dining experiences in Maryland. These top-rated brewpubs offer fresh house-brewed pints perfectly paired with artisanal kitchen menus.',
-    filterFn: (b) => b.type === 'Brewpub'
+    badge: 'Brewery Type',
+    title: 'Best Brewpubs in Maryland | Food & Craft Beer',
+    desc: 'Browse prime craft beer dining experiences in Maryland. These top-rated brewpubs serve fresh house-brewed pints perfectly paired with artisanal kitchen menus.',
+    icon: <Utensils className="w-4 h-4 text-amber-400" />,
+    filterFn: (b) => b.type === 'Brewpub',
   },
-  'production': {
+  production: {
     name: 'Production Brewery',
-    title: 'Production Breweries in Maryland | Large Taprooms',
-    desc: 'Discover large-scale production breweries in Maryland. Take facility tours, explore extensive industrial tasting rooms, and taste famous flagship beers.',
-    filterFn: (b) => b.type === 'Production'
+    badge: 'Brewery Type',
+    title: 'Production Breweries in Maryland | Tasting Rooms',
+    desc: 'Discover large-scale production breweries in Maryland. Tour commercial brewing facilities, explore industrial tasting rooms, and try flagship craft beers.',
+    icon: <Factory className="w-4 h-4 text-amber-400" />,
+    filterFn: (b) => b.type === 'Production',
   },
   'farm-brewery': {
     name: 'Farm Brewery',
-    title: 'Farm Breweries in Maryland | Rural Taprooms',
-    desc: 'Experience scenic farm-to-glass brewing in Maryland. These farm breweries operate on active rural agricultural lands, offering beautiful open-air spaces.',
-    filterFn: (b) => b.type === 'Farm Brewery'
-  }
+    badge: 'Brewery Type',
+    title: 'Farm Breweries in Maryland | Open-Air Taprooms',
+    desc: 'Experience scenic farm-to-glass brewing in Maryland. Farm breweries operate on active rural agricultural lands, offering family-friendly open spaces.',
+    icon: <Trees className="w-4 h-4 text-amber-400" />,
+    filterFn: (b) => b.type === 'Farm Brewery',
+  },
 };
 
 async function getCategoryData(slug: string) {
-  const category = CATEGORY_MAP[slug.toLowerCase()];
+  const categoryKey = slug.toLowerCase();
+  const category = CATEGORY_MAP[categoryKey];
   if (!category) return null;
 
   const breweries = await contentService.breweries.getAll();
@@ -56,7 +75,8 @@ async function getCategoryData(slug: string) {
 
   return {
     ...category,
-    breweries: matchedBreweries
+    slug: categoryKey,
+    breweries: matchedBreweries,
   };
 }
 
@@ -66,19 +86,21 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
 
   if (!data) {
     return {
-      title: "Category Not Found | Maryland Beer Atlas",
+      title: 'Category Not Found | Maryland Beer Atlas',
     };
   }
 
+  const countText = `${data.breweries.length} ${data.breweries.length === 1 ? 'brewery' : 'breweries'}`;
+
   return {
-    title: `${data.title} | Top Taprooms`,
-    description: data.desc,
+    title: `${data.title} (${data.breweries.length}) | Maryland Beer Atlas`,
+    description: `${data.desc} Browse ${countText} with taproom hours, amenities, and directions.`,
     openGraph: {
-      title: `${data.title} | Top MD Taprooms`,
+      title: `${data.title} (${data.breweries.length}) | Maryland Beer Atlas`,
       description: data.desc,
       url: `https://marylandbeeratlas.com/breweries/category/${slug}`,
-      type: 'website'
-    }
+      type: 'website',
+    },
   };
 }
 
@@ -91,29 +113,29 @@ export default async function CategoryLandingPage({ params }: CategoryPageProps)
   }
 
   const listSchema = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    "name": data.title,
-    "description": data.desc,
-    "numberOfItems": data.breweries.length,
-    "itemListElement": data.breweries.map((brewery, index) => ({
-      "@type": "ListItem",
-      "position": index + 1,
-      "item": {
-        "@type": "Brewery",
-        "name": brewery.name,
-        "description": brewery.description,
-        "image": brewery.image,
-        "url": `https://marylandbeeratlas.com/breweries/${brewery.slug}`,
-        "address": {
-          "@type": "PostalAddress",
-          "streetAddress": brewery.address,
-          "addressLocality": brewery.city,
-          "addressRegion": "MD",
-          "postalCode": brewery.zipCode
-        }
-      }
-    }))
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: data.title,
+    description: data.desc,
+    numberOfItems: data.breweries.length,
+    itemListElement: data.breweries.map((brewery, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'Brewery',
+        name: brewery.name,
+        description: brewery.description,
+        image: brewery.image,
+        url: `https://marylandbeeratlas.com/breweries/${brewery.slug}`,
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: brewery.address,
+          addressLocality: brewery.city,
+          addressRegion: 'MD',
+          postalCode: brewery.zipCode,
+        },
+      },
+    })),
   };
 
   return (
@@ -137,19 +159,25 @@ export default async function CategoryLandingPage({ params }: CategoryPageProps)
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.15),transparent_45%)]" />
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(34,197,94,0.06),transparent_40%)]" />
           <div className="relative z-10 space-y-4 max-w-3xl">
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/20">
-              Maryland Beer Guide
-            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/20">
+                {data.icon || <Tag className="w-3.5 h-3.5" />}
+                {data.badge}
+              </span>
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold bg-zinc-800 text-zinc-200 border border-zinc-700">
+                {data.breweries.length} {data.breweries.length === 1 ? 'Brewery' : 'Breweries'}
+              </span>
+            </div>
             <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight leading-tight">
               {data.title}
             </h1>
-            <p className="text-zinc-300 text-base md:text-lg leading-relaxed">
-              {data.desc} Explore high-quality craft venues and enjoy premium vibes.
+            <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-normal">
+              {data.desc} Explore high-quality craft venues, taprooms, and outdoor spaces across Maryland.
             </p>
           </div>
         </div>
 
-        {/* Brewery List Grid */}
+        {/* Brewery List Grid or Empty State */}
         {data.breweries.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
             {data.breweries.map((brewery) => (
@@ -157,9 +185,11 @@ export default async function CategoryLandingPage({ params }: CategoryPageProps)
             ))}
           </div>
         ) : (
-          <div className="text-center p-12 bg-white dark:bg-zinc-950 rounded-2xl border border-zinc-200 dark:border-zinc-850">
-            <p className="text-zinc-600 dark:text-zinc-400">No breweries found in this category currently.</p>
-          </div>
+          <EmptyState
+            title={`No Breweries Found for "${data.name}"`}
+            description="We currently don't have any verified active craft breweries matching this specific category. Explore other categories or view our full brewery directory."
+            icon="beer"
+          />
         )}
       </PageContainer>
     </div>

--- a/app/breweries/county/[slug]/page.tsx
+++ b/app/breweries/county/[slug]/page.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, MapPin } from 'lucide-react';
 import { contentService } from '@/lib/services/content.service';
 import { PageContainer } from '@/components/layout/page-container';
 import { BreweryCard } from '@/components/ui/brewery-card';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface CountyPageProps {
   params: Promise<{ slug: string }>;
 }
 
-// Function to convert County name to a URL slug
-function slugifyCounty(countyName: string): string {
+// Helper to convert County name to a URL slug
+export function slugifyCounty(countyName: string): string {
   return countyName
     .toLowerCase()
     .replace(/'/g, '') // Prince George's -> prince-georges
@@ -23,20 +24,23 @@ function slugifyCounty(countyName: string): string {
 async function getCountyData(slug: string) {
   const breweries = await contentService.breweries.getAll();
 
-  // Find unique county names from our breweries
-  const uniqueCounties = Array.from(new Set(breweries.map(b => b.county)));
+  // Find unique county names from our canonical brewery data
+  const uniqueCounties = Array.from(new Set(breweries.map((b) => b.county)));
 
   // Find which county matches the slug
-  const matchedCounty = uniqueCounties.find(county => slugifyCounty(county) === slug);
+  const matchedCounty = uniqueCounties.find((county) => slugifyCounty(county) === slug);
 
   if (!matchedCounty) {
     return null;
   }
 
-  const countyBreweries = breweries.filter(b => b.county === matchedCounty);
+  const countyBreweries = breweries.filter((b) => b.county === matchedCounty);
+  const region = countyBreweries.length > 0 ? countyBreweries[0].region : undefined;
+
   return {
     countyName: matchedCounty,
-    breweries: countyBreweries
+    region,
+    breweries: countyBreweries,
   };
 }
 
@@ -46,19 +50,21 @@ export async function generateMetadata({ params }: CountyPageProps): Promise<Met
 
   if (!data) {
     return {
-      title: "County Not Found | Maryland Beer Atlas",
+      title: 'County Not Found | Maryland Beer Atlas',
     };
   }
 
+  const countText = `${data.breweries.length} ${data.breweries.length === 1 ? 'brewery' : 'breweries'}`;
+
   return {
-    title: `Best Breweries in ${data.countyName} MD | Top Local Taprooms`,
-    description: `Discover the best craft breweries in ${data.countyName} County, Maryland. Explore taprooms, check amenities, and map your next brewery visit in ${data.countyName} MD.`,
+    title: `Best Breweries in ${data.countyName} County MD (${data.breweries.length}) | Taprooms & Map`,
+    description: `Discover ${countText} in ${data.countyName} County, Maryland. Explore craft taprooms, check amenities, hours, and map out your next brewery visit in ${data.countyName} MD.`,
     openGraph: {
-      title: `Best Breweries in ${data.countyName} MD | Top Local Taprooms`,
-      description: `Discover the best craft breweries in ${data.countyName} County, Maryland. Explore taprooms, check amenities, and map your next brewery visit in ${data.countyName} MD.`,
+      title: `Best Breweries in ${data.countyName} County MD | Maryland Beer Atlas`,
+      description: `Discover ${countText} in ${data.countyName} County, Maryland. Check hours, dog-friendly outdoor seating, and directions.`,
       url: `https://marylandbeeratlas.com/breweries/county/${slug}`,
-      type: 'website'
-    }
+      type: 'website',
+    },
   };
 }
 
@@ -71,29 +77,29 @@ export default async function CountyLandingPage({ params }: CountyPageProps) {
   }
 
   const listSchema = {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    "name": `Breweries in ${data.countyName} County, MD`,
-    "description": `A curated list of local craft breweries located in ${data.countyName} County, Maryland.`,
-    "numberOfItems": data.breweries.length,
-    "itemListElement": data.breweries.map((brewery, index) => ({
-      "@type": "ListItem",
-      "position": index + 1,
-      "item": {
-        "@type": "Brewery",
-        "name": brewery.name,
-        "description": brewery.description,
-        "image": brewery.image,
-        "url": `https://marylandbeeratlas.com/breweries/${brewery.slug}`,
-        "address": {
-          "@type": "PostalAddress",
-          "streetAddress": brewery.address,
-          "addressLocality": brewery.city,
-          "addressRegion": "MD",
-          "postalCode": brewery.zipCode
-        }
-      }
-    }))
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Breweries in ${data.countyName} County, MD`,
+    description: `A curated list of ${data.breweries.length} local craft breweries located in ${data.countyName} County, Maryland.`,
+    numberOfItems: data.breweries.length,
+    itemListElement: data.breweries.map((brewery, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'Brewery',
+        name: brewery.name,
+        description: brewery.description,
+        image: brewery.image,
+        url: `https://marylandbeeratlas.com/breweries/${brewery.slug}`,
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: brewery.address,
+          addressLocality: brewery.city,
+          addressRegion: 'MD',
+          postalCode: brewery.zipCode,
+        },
+      },
+    })),
   };
 
   return (
@@ -117,24 +123,46 @@ export default async function CountyLandingPage({ params }: CountyPageProps) {
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(245,158,11,0.15),transparent_45%)]" />
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,rgba(34,197,94,0.06),transparent_40%)]" />
           <div className="relative z-10 space-y-4 max-w-3xl">
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/20">
-              Maryland County Guide
-            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-amber-500/10 text-amber-400 border border-amber-500/20">
+                <MapPin className="w-3.5 h-3.5" />
+                Maryland County Discovery
+              </span>
+              {data.region && (
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+                  {data.region} Region
+                </span>
+              )}
+              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-bold bg-zinc-800 text-zinc-200 border border-zinc-700">
+                {data.breweries.length} {data.breweries.length === 1 ? 'Brewery' : 'Breweries'}
+              </span>
+            </div>
             <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight leading-tight">
-              Best Breweries in <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-amber-600">{data.countyName} County</span>
+              Best Breweries in{' '}
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-amber-400 to-amber-600">
+                {data.countyName} County
+              </span>
             </h1>
-            <p className="text-zinc-300 text-base md:text-lg leading-relaxed">
-              Explore the premier craft beer destinations and local taprooms in {data.countyName} County, Maryland. Find coordinates, styles, and details for your next visit.
+            <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-normal">
+              Explore the premier craft beer destinations, independent microbreweries, and local taprooms in {data.countyName} County, Maryland. Check operational hours, amenities, and directions for your next visit.
             </p>
           </div>
         </div>
 
-        {/* Brewery List Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {data.breweries.map((brewery) => (
-            <BreweryCard key={brewery.id} brewery={brewery} />
-          ))}
-        </div>
+        {/* Brewery List Grid or Empty State */}
+        {data.breweries.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {data.breweries.map((brewery) => (
+              <BreweryCard key={brewery.id} brewery={brewery} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            title={`No Breweries Found in ${data.countyName} County`}
+            description="We currently don't have any verified active craft breweries cataloged in this county. Explore other nearby Maryland counties or browse the full directory."
+            icon="beer"
+          />
+        )}
       </PageContainer>
     </div>
   );

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -6,14 +6,14 @@ export function Footer() {
 
   return (
     <footer className="w-full border-t border-emerald-950/10 dark:border-zinc-800 bg-zinc-950 text-zinc-300">
-      {/* Subtle outdoor graphic line/pattern */}
+      {/* Outdoor graphic line */}
       <div className="h-1.5 w-full bg-gradient-to-r from-emerald-800 via-amber-500 to-amber-700" />
 
       <div className="container mx-auto px-4 md:px-6 py-16 max-w-6xl">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
 
           {/* Brand Info */}
-          <div className="md:col-span-7 space-y-5">
+          <div className="md:col-span-5 space-y-5">
             <Link
               href="/"
               className="flex items-center space-x-2.5 text-zinc-50 group focus-visible:outline-2 focus-visible:outline-amber-500 rounded-lg w-fit"
@@ -26,21 +26,21 @@ export function Footer() {
                 Maryland <span className="text-amber-500">Beer Atlas</span>
               </span>
             </Link>
-            <p className="text-sm text-zinc-400 max-w-xl leading-relaxed font-normal">
-              Establishing the ultimate curated guide to Maryland&apos;s vibrant craft beer community. Explore beautiful farm breweries, historic taprooms, and dynamic beer trails across our great state.
+            <p className="text-sm text-zinc-400 max-w-md leading-relaxed font-normal">
+              Establishing the ultimate curated guide to Maryland&apos;s vibrant craft beer community. Explore beautiful farm breweries, historic taprooms, and dynamic beer trails across our state.
             </p>
             <div className="flex items-center gap-2 text-xs text-zinc-500">
               <MapPin className="w-3.5 h-3.5 text-amber-500" />
-              <span>Mapping local adventure across Maryland</span>
+              <span>Mapping local craft beer across Maryland</span>
             </div>
           </div>
 
-          {/* Directory Links */}
-          <div className="md:col-span-5 space-y-4">
+          {/* Core Navigation Links */}
+          <div className="md:col-span-3 space-y-4">
             <h3 className="text-xs font-bold text-zinc-50 uppercase tracking-widest border-l-2 border-amber-500 pl-2.5">
-              Explore Maryland
+              Explore Atlas
             </h3>
-            <ul className="space-y-2.5 text-sm font-medium">
+            <ul className="space-y-2 text-sm font-medium">
               <li>
                 <Link href="/breweries" className="text-zinc-400 hover:text-amber-400 transition-colors focus-visible:outline-2 focus-visible:outline-amber-500 rounded px-1 -mx-1 py-0.5">
                   Brewery Directory
@@ -63,12 +63,42 @@ export function Footer() {
               </li>
             </ul>
           </div>
+
+          {/* Popular Counties & Brewery Types SEO Links */}
+          <div className="md:col-span-4 space-y-4">
+            <h3 className="text-xs font-bold text-zinc-50 uppercase tracking-widest border-l-2 border-amber-500 pl-2.5">
+              Counties & Categories
+            </h3>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs font-medium text-zinc-400">
+              <div className="space-y-1.5">
+                <span className="block font-bold text-[10px] text-zinc-500 uppercase tracking-wider">Counties</span>
+                <ul className="space-y-1">
+                  <li><Link href="/breweries/county/frederick" className="hover:text-amber-400 transition-colors">Frederick</Link></li>
+                  <li><Link href="/breweries/county/baltimore-city" className="hover:text-amber-400 transition-colors">Baltimore City</Link></li>
+                  <li><Link href="/breweries/county/montgomery" className="hover:text-amber-400 transition-colors">Montgomery</Link></li>
+                  <li><Link href="/breweries/county/baltimore-county" className="hover:text-amber-400 transition-colors">Baltimore County</Link></li>
+                  <li><Link href="/breweries/county/prince-georges" className="hover:text-amber-400 transition-colors">Prince George&apos;s</Link></li>
+                </ul>
+              </div>
+              <div className="space-y-1.5">
+                <span className="block font-bold text-[10px] text-zinc-500 uppercase tracking-wider">Categories</span>
+                <ul className="space-y-1">
+                  <li><Link href="/breweries/category/dog-friendly" className="hover:text-amber-400 transition-colors">🐕 Dog-Friendly</Link></li>
+                  <li><Link href="/breweries/category/microbrewery" className="hover:text-amber-400 transition-colors">Microbreweries</Link></li>
+                  <li><Link href="/breweries/category/brewpub" className="hover:text-amber-400 transition-colors">Brewpubs</Link></li>
+                  <li><Link href="/breweries/category/farm-brewery" className="hover:text-amber-400 transition-colors">Farm Breweries</Link></li>
+                  <li><Link href="/breweries/category/production" className="hover:text-amber-400 transition-colors">Production</Link></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+
         </div>
 
         {/* Divider */}
         <div className="border-t border-zinc-800 my-10" />
 
-        {/* Copyright and signature */}
+        {/* Copyright */}
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-xs text-zinc-500">
           <div>
             &copy; {currentYear} Maryland Beer Atlas. All rights reserved.

--- a/components/ui/__tests__/county-and-category-discovery.test.tsx
+++ b/components/ui/__tests__/county-and-category-discovery.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { slugifyCounty } from '@/app/breweries/county/[slug]/page';
+import { CATEGORY_MAP } from '@/app/breweries/category/[slug]/page';
+import { Brewery } from '@/lib/types';
+
+const sampleBreweries: Brewery[] = [
+  {
+    id: '1',
+    slug: 'flying-dog',
+    name: 'Flying Dog Brewery',
+    type: 'Microbrewery',
+    region: 'Western',
+    status: 'Open',
+    address: '4607 Wedgewood Blvd',
+    city: 'Frederick',
+    county: 'Frederick',
+    state: 'MD',
+    zipCode: '21703',
+    phone: '301-694-7899',
+    website: 'https://flyingdogbrewery.com',
+    socialLinks: {},
+    coordinates: { lat: 39.3623, lng: -77.4262 },
+    description: 'Iconic Frederick microbrewery.',
+    image: 'https://images.unsplash.com/photo-1550345332-09e3ac987658',
+    hours: [],
+    structuredHours: [],
+    beerStyles: ['IPA'],
+    amenities: ['Dog Friendly', 'Outdoor Seating'],
+    featured: true,
+    lastVerified: '2026-08-01',
+    verificationSource: 'Official Website',
+    verificationStatus: 'Verified',
+  },
+  {
+    id: '2',
+    slug: 'franklins',
+    name: "Franklin's General Store & Brewery",
+    type: 'Brewpub',
+    region: 'Capital',
+    status: 'Open',
+    address: '5123 Baltimore Ave',
+    city: 'Hyattsville',
+    county: "Prince George's",
+    state: 'MD',
+    zipCode: '20781',
+    phone: '301-927-2740',
+    website: 'https://franklinsbrewery.com',
+    socialLinks: {},
+    coordinates: { lat: 38.9553, lng: -76.9402 },
+    description: 'Hyattsville brewpub.',
+    image: 'https://images.unsplash.com/photo-1550345332-09e3ac987658',
+    hours: [],
+    structuredHours: [],
+    beerStyles: ['Stout'],
+    amenities: ['Food Menu'],
+    featured: false,
+    lastVerified: '2026-08-01',
+    verificationSource: 'Official Website',
+    verificationStatus: 'Verified',
+  },
+  {
+    id: '3',
+    slug: 'elder-pine',
+    name: 'Elder Pine Brewing & Blending',
+    type: 'Farm Brewery',
+    region: 'Capital',
+    status: 'Open',
+    address: '4200 Sundown Rd',
+    city: 'Gaithersburg',
+    county: 'Montgomery',
+    state: 'MD',
+    zipCode: '20882',
+    phone: '301-555-0199',
+    website: 'https://elderpine.com',
+    socialLinks: {},
+    coordinates: { lat: 39.2312, lng: -77.0987 },
+    description: 'Scenic farm brewery in Montgomery County.',
+    image: 'https://images.unsplash.com/photo-1550345332-09e3ac987658',
+    hours: [],
+    structuredHours: [],
+    beerStyles: ['Lager', 'Wild Ale'],
+    amenities: ['Dog Friendly', 'Outdoor Seating'],
+    featured: true,
+    lastVerified: '2026-08-01',
+    verificationSource: 'Official Website',
+    verificationStatus: 'Verified',
+  },
+  {
+    id: '4',
+    slug: 'heavy-seas',
+    name: 'Heavy Seas Beer',
+    type: 'Production',
+    region: 'Central',
+    status: 'Open',
+    address: '4615 Hollins Ferry Rd',
+    city: 'Halethorpe',
+    county: 'Baltimore County',
+    state: 'MD',
+    zipCode: '21227',
+    phone: '410-247-7822',
+    website: 'https://hsbeer.com',
+    socialLinks: {},
+    coordinates: { lat: 39.2274, lng: -76.6669 },
+    description: 'Large scale production brewery.',
+    image: 'https://images.unsplash.com/photo-1550345332-09e3ac987658',
+    hours: [],
+    structuredHours: [],
+    beerStyles: ['IPA', 'Amber Ale'],
+    amenities: ['Tasting Room'],
+    featured: false,
+    lastVerified: '2026-08-01',
+    verificationSource: 'Official Website',
+    verificationStatus: 'Verified',
+  },
+];
+
+describe('County and Category Discovery Logic', () => {
+  describe('slugifyCounty', () => {
+    it('converts county names into standardized URL slugs', () => {
+      expect(slugifyCounty("Prince George's")).toBe('prince-georges');
+      expect(slugifyCounty('Baltimore City')).toBe('baltimore-city');
+      expect(slugifyCounty('Baltimore County')).toBe('baltimore-county');
+      expect(slugifyCounty('Anne Arundel')).toBe('anne-arundel');
+      expect(slugifyCounty('Frederick')).toBe('frederick');
+    });
+  });
+
+  describe('CATEGORY_MAP Filter Logic', () => {
+    it('filters dog-friendly breweries accurately', () => {
+      const dogFriendlyDef = CATEGORY_MAP['dog-friendly'];
+      expect(dogFriendlyDef).toBeDefined();
+
+      const matched = sampleBreweries.filter(dogFriendlyDef.filterFn);
+      expect(matched.map((b) => b.slug)).toEqual(['flying-dog', 'elder-pine']);
+    });
+
+    it('filters brewpubs accurately', () => {
+      const brewpubDef = CATEGORY_MAP['brewpub'];
+      expect(brewpubDef).toBeDefined();
+
+      const matched = sampleBreweries.filter(brewpubDef.filterFn);
+      expect(matched.map((b) => b.slug)).toEqual(['franklins']);
+    });
+
+    it('filters farm breweries accurately', () => {
+      const farmDef = CATEGORY_MAP['farm-brewery'];
+      expect(farmDef).toBeDefined();
+
+      const matched = sampleBreweries.filter(farmDef.filterFn);
+      expect(matched.map((b) => b.slug)).toEqual(['elder-pine']);
+    });
+
+    it('filters production breweries accurately', () => {
+      const prodDef = CATEGORY_MAP['production'];
+      expect(prodDef).toBeDefined();
+
+      const matched = sampleBreweries.filter(prodDef.filterFn);
+      expect(matched.map((b) => b.slug)).toEqual(['heavy-seas']);
+    });
+
+    it('filters microbreweries accurately', () => {
+      const microDef = CATEGORY_MAP['microbrewery'];
+      expect(microDef).toBeDefined();
+
+      const matched = sampleBreweries.filter(microDef.filterFn);
+      expect(matched.map((b) => b.slug)).toEqual(['flying-dog']);
+    });
+  });
+});

--- a/components/ui/breweries-directory-content.tsx
+++ b/components/ui/breweries-directory-content.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useState, useEffect, useRef, Suspense } from 'react';
+import React, { useState, useEffect, useRef, useMemo, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { Search, Filter, RotateCcw, Beer as BeerIcon, Activity, ArrowUpDown } from 'lucide-react';
+import { Search, Filter, RotateCcw, Beer as BeerIcon, Activity, ArrowUpDown, MapPin, Tag, Dog, Utensils, Factory, Trees } from 'lucide-react';
 import { Brewery, BreweryType, MarylandRegion, OperationalCategory } from '@/lib/types';
 import { BreweryCard } from '@/components/ui/brewery-card';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -56,6 +56,21 @@ const SORT_OPTIONS: { label: string; value: BrewerySortOption }[] = [
   { label: 'Recently Verified', value: 'verified-desc' },
 ];
 
+function slugifyCounty(countyName: string): string {
+  return countyName
+    .toLowerCase()
+    .replace(/'/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+}
+
+const CATEGORY_SLUG_MAP: Record<string, string> = {
+  Microbrewery: 'microbrewery',
+  Brewpub: 'brewpub',
+  Production: 'production',
+  'Farm Brewery': 'farm-brewery',
+};
+
 function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirectoryContentProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -83,11 +98,34 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
   const regions: MarylandRegion[] = ['Capital', 'Central', 'Eastern Shore', 'Southern', 'Western'];
   const breweryTypes: BreweryType[] = ['Microbrewery', 'Brewpub', 'Production', 'Farm Brewery'];
 
-  // Dynamically extract unique counties and amenities from the provided dataset
-  const counties = Array.from(new Set(breweries.map((b) => b.county))).sort();
-  const amenities = Array.from(new Set(breweries.flatMap((b) => b.amenities))).sort();
+  // Dynamically extract unique counties and amenities from dataset
+  const counties = useMemo(() => Array.from(new Set(breweries.map((b) => b.county))).sort(), [breweries]);
+  const amenities = useMemo(() => Array.from(new Set(breweries.flatMap((b) => b.amenities))).sort(), [breweries]);
 
-  // Keep track of the parameters currently reflected in the URL
+  // Counts per County
+  const countyCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    breweries.forEach((b) => {
+      counts[b.county] = (counts[b.county] || 0) + 1;
+    });
+    return counts;
+  }, [breweries]);
+
+  // Counts per Brewery Type
+  const typeCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    breweries.forEach((b) => {
+      counts[b.type] = (counts[b.type] || 0) + 1;
+    });
+    return counts;
+  }, [breweries]);
+
+  // Count for Dog Friendly
+  const dogFriendlyCount = useMemo(() => {
+    return breweries.filter((b) => b.amenities.some((a) => a.toLowerCase().includes('dog friendly'))).length;
+  }, [breweries]);
+
+  // Keep track of parameters currently reflected in URL
   const prevParamsRef = useRef<{
     search: string;
     region: MarylandRegion | '';
@@ -108,7 +146,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     sort: initialSort,
   });
 
-  // Keep a ref to current filter values for debounced search sync
   const filterStateRef = useRef({
     selectedRegion,
     selectedType,
@@ -117,6 +154,7 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     selectedStatus,
     selectedSort,
   });
+
   useEffect(() => {
     filterStateRef.current = {
       selectedRegion,
@@ -128,7 +166,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     };
   }, [selectedRegion, selectedType, selectedCounty, selectedAmenity, selectedStatus, selectedSort]);
 
-  // Sync state with URL search params when they change (e.g., back/forward buttons)
   useEffect(() => {
     const currentSearch = searchParams?.get('search') || '';
     const currentRegion = searchParams?.get('region') || '';
@@ -173,7 +210,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     }
   }, [searchParams]);
 
-  // Update URL Search Params to persist filter states
   const applyFilters = (
     search: string,
     region: string,
@@ -204,7 +240,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     }
   };
 
-  // Debounced Search Query Sync
   useEffect(() => {
     const currentSearch = searchParams?.get('search') || '';
     if (searchQuery === currentSearch) return;
@@ -317,11 +352,10 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
     router.push('/breweries');
   };
 
-  // Centralized filter logic execution
   const filteredBreweries = filterBreweries(breweries, {
     search: searchQuery,
-    region: selectedRegion,
-    type: selectedType,
+    region: selectedRegion || undefined,
+    type: selectedType || undefined,
     county: selectedCounty,
     amenity: selectedAmenity,
     status: selectedStatus,
@@ -334,7 +368,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
       <div className="bg-white dark:bg-zinc-950 p-6 rounded-2xl border border-zinc-200 dark:border-zinc-850 shadow-sm mb-10 space-y-4">
         {/* Row 1: Search & Popular Guides preset select */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Search Input */}
           <div className="relative">
             <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-zinc-400 w-5 h-5" />
             <input
@@ -347,7 +380,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
             />
           </div>
 
-          {/* Popular Guides Preset Select */}
           <div className="relative">
             <select
               value={selectedQuickGuide}
@@ -370,7 +402,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
 
         {/* Row 2: Standard Filtering dropdowns & Reset button */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7 gap-4">
-          {/* Region Select */}
           <div className="relative">
             <select
               value={selectedRegion}
@@ -388,7 +419,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
             <Filter className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* County Select */}
           <div className="relative">
             <select
               value={selectedCounty}
@@ -399,14 +429,13 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
               <option value="">All Counties</option>
               {counties.map((county) => (
                 <option key={county} value={county}>
-                  {county} County
+                  {county} County ({countyCounts[county] || 0})
                 </option>
               ))}
             </select>
             <Filter className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* Brewery Type Select */}
           <div className="relative">
             <select
               value={selectedType}
@@ -417,14 +446,13 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
               <option value="">All Brewery Types</option>
               {breweryTypes.map((type) => (
                 <option key={type} value={type}>
-                  {type}
+                  {type} ({typeCounts[type] || 0})
                 </option>
               ))}
             </select>
             <BeerIcon className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* Operational Status Select */}
           <div className="relative">
             <select
               value={selectedStatus}
@@ -441,7 +469,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
             <Activity className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* Amenity Filter */}
           <div className="relative">
             <select
               value={selectedAmenity}
@@ -459,7 +486,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
             <Filter className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* Sort By Select */}
           <div className="relative">
             <select
               value={selectedSort}
@@ -476,7 +502,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
             <ArrowUpDown className="absolute right-4 top-1/2 -translate-y-1/2 text-zinc-400 w-4 h-4 pointer-events-none" />
           </div>
 
-          {/* Reset Button */}
           <div>
             <button
               onClick={resetFilters}
@@ -518,7 +543,98 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
         />
       )}
 
-      {/* Connected Curated Travel Guides & Popular Local Regions Showcase */}
+      {/* Dynamic Discovery Sections: Browse by County and Browse by Category */}
+      <div className="mt-16 pt-12 border-t border-zinc-200 dark:border-zinc-850 space-y-10">
+        {/* County Discovery Grid */}
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-50 flex items-center gap-2">
+              <MapPin className="w-5 h-5 text-amber-500" />
+              Browse Breweries by County
+            </h3>
+            <span className="text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+              {counties.length} Maryland Counties
+            </span>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3">
+            {counties.map((county) => {
+              const count = countyCounts[county] || 0;
+              const slug = slugifyCounty(county);
+              return (
+                <Link
+                  key={county}
+                  href={`/breweries/county/${slug}`}
+                  className="p-3.5 rounded-xl bg-white dark:bg-zinc-950 hover:bg-amber-50 dark:hover:bg-amber-950/20 border border-zinc-200 dark:border-zinc-850 hover:border-amber-400 transition-all text-center group flex flex-col justify-between"
+                >
+                  <span className="font-bold text-xs text-zinc-900 dark:text-zinc-100 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors line-clamp-1">
+                    {county}
+                  </span>
+                  <span className="text-[10px] text-zinc-500 dark:text-zinc-400 mt-1 font-medium">
+                    {count} {count === 1 ? 'brewery' : 'breweries'}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Category & Type Discovery Cards */}
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-50 flex items-center gap-2">
+              <Tag className="w-5 h-5 text-amber-500" />
+              Browse by Category & Style
+            </h3>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+            <Link
+              href="/breweries/category/dog-friendly"
+              className="p-4 rounded-xl bg-white dark:bg-zinc-950 hover:bg-amber-50 dark:hover:bg-amber-950/20 border border-zinc-200 dark:border-zinc-850 hover:border-amber-400 transition-all group flex flex-col justify-between"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <div className="p-2 rounded-lg bg-amber-500/10 text-amber-500">
+                  <Dog className="w-4 h-4" />
+                </div>
+                <span className="font-bold text-xs text-zinc-900 dark:text-zinc-100 group-hover:text-amber-600 dark:group-hover:text-amber-400">
+                  Dog-Friendly
+                </span>
+              </div>
+              <p className="text-[11px] text-zinc-500 dark:text-zinc-400 leading-tight">
+                {dogFriendlyCount} taprooms with outdoor seating for dogs
+              </p>
+            </Link>
+
+            {breweryTypes.map((type) => {
+              const count = typeCounts[type] || 0;
+              const slug = CATEGORY_SLUG_MAP[type] || type.toLowerCase();
+              let icon = <BeerIcon className="w-4 h-4" />;
+              if (type === 'Brewpub') icon = <Utensils className="w-4 h-4" />;
+              if (type === 'Production') icon = <Factory className="w-4 h-4" />;
+              if (type === 'Farm Brewery') icon = <Trees className="w-4 h-4" />;
+
+              return (
+                <Link
+                  key={type}
+                  href={`/breweries/category/${slug}`}
+                  className="p-4 rounded-xl bg-white dark:bg-zinc-950 hover:bg-amber-50 dark:hover:bg-amber-950/20 border border-zinc-200 dark:border-zinc-850 hover:border-amber-400 transition-all group flex flex-col justify-between"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <div className="p-2 rounded-lg bg-amber-500/10 text-amber-500">{icon}</div>
+                    <span className="font-bold text-xs text-zinc-900 dark:text-zinc-100 group-hover:text-amber-600 dark:group-hover:text-amber-400">
+                      {type}
+                    </span>
+                  </div>
+                  <p className="text-[11px] text-zinc-500 dark:text-zinc-400 leading-tight">
+                    {count} active {count === 1 ? 'brewery' : 'breweries'}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Connected Curated Travel Guides Showcase */}
       {guides.length > 0 && (
         <div className="mt-16 pt-12 border-t border-zinc-200 dark:border-zinc-850 space-y-8">
           <div className="flex flex-col md:flex-row md:items-end justify-between gap-3">
@@ -590,41 +706,6 @@ function BreweriesDirectoryContent({ breweries, guides = [] }: BreweriesDirector
                 </div>
               </div>
             ))}
-          </div>
-
-          {/* Quick crawlable subcategories / popular counties SEO shortcuts block */}
-          <div className="p-6 rounded-2xl bg-zinc-50 dark:bg-zinc-950 border border-zinc-200 dark:border-zinc-850 grid grid-cols-2 md:grid-cols-4 gap-6">
-            <div className="space-y-2">
-              <span className="block text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Popular Counties</span>
-              <ul className="space-y-1.5 text-xs font-semibold text-zinc-600 dark:text-zinc-400">
-                <li><Link href="/breweries/county/frederick" className="hover:text-amber-500 transition-colors">Frederick County</Link></li>
-                <li><Link href="/breweries/county/baltimore-city" className="hover:text-amber-500 transition-colors">Baltimore City</Link></li>
-              </ul>
-            </div>
-            <div className="space-y-2">
-              <span className="block text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">More Counties</span>
-              <ul className="space-y-1.5 text-xs font-semibold text-zinc-600 dark:text-zinc-400">
-                <li><Link href="/breweries/county/montgomery" className="hover:text-amber-500 transition-colors">Montgomery County</Link></li>
-                <li><Link href="/breweries/county/baltimore-county" className="hover:text-amber-500 transition-colors">Baltimore County</Link></li>
-              </ul>
-            </div>
-            <div className="space-y-2">
-              <span className="block text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Dog-Friendly</span>
-              <ul className="space-y-1.5 text-xs font-bold text-amber-600 dark:text-amber-400">
-                <li>
-                  <Link href="/breweries/category/dog-friendly" className="hover:underline flex items-center gap-1">
-                    🐕 Dog-Friendly Taprooms
-                  </Link>
-                </li>
-              </ul>
-            </div>
-            <div className="space-y-2">
-              <span className="block text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">Brewery Types</span>
-              <ul className="space-y-1.5 text-xs font-semibold text-zinc-600 dark:text-zinc-400">
-                <li><Link href="/breweries/category/farm-brewery" className="hover:text-amber-500 transition-colors">Farm Breweries</Link></li>
-                <li><Link href="/breweries/category/brewpub" className="hover:text-amber-500 transition-colors">Local Brewpubs</Link></li>
-              </ul>
-            </div>
           </div>
         </div>
       )}

--- a/dev_server.log
+++ b/dev_server.log
@@ -5,19 +5,22 @@
 ▲ Next.js 16.3.0 (Turbopack)
 - Local:         http://localhost:3000
 - Network:       http://192.168.0.2:3000
-✓ Ready in 565ms
-✓ Running next.config.ts took 48ms
+✓ Ready in 532ms
+✓ Running next.config.ts took 44ms
 
 ○ Compiling / ...
- HEAD / 200 in 5.3s (next.js: 4.6s, application-code: 700ms)
- GET /breweries/flying-dog-brewery 200 in 3.5s (next.js: 2.7s, application-code: 818ms)
- GET /breweries/flying-dog-brewery 200 in 229ms (next.js: 24ms, application-code: 204ms)
-[browser] Attempted to synchronously unmount a root while React was already rendering. React cannot finish unmounting the root until the current render has completed, which may lead to a race condition.
-    at BreweryDetailMap.useEffect (components/ui/brewery-detail-map.tsx:167:32)
-  165 |       if (popupRootRef.current) {
-  166 |         try {
-> 167 |           popupRootRef.current.unmount();
-      |                                ^
-  168 |         } catch {
-  169 |           // ignore
-  170 |         } (components/ui/brewery-detail-map.tsx:167:32)
+ GET / 200 in 4.7s (next.js: 4.0s, application-code: 685ms)
+⨯ upstream image response failed for https://images.unsplash.com/photo-1608270176050-12ec057de8d8?auto=format&fit=crop&q=80&w=800 404
+ GET /breweries 200 in 1742ms (next.js: 1635ms, application-code: 107ms)
+⨯ upstream image response failed for https://images.unsplash.com/photo-1608270176050-12ec057de8d8?auto=format&fit=crop&q=80&w=800 404
+ GET /breweries 200 in 241ms (next.js: 5ms, application-code: 236ms)
+⨯ upstream image response failed for https://images.unsplash.com/photo-1608270176050-12ec057de8d8?auto=format&fit=crop&q=80&w=800 404
+ GET /breweries/county/frederick 200 in 1664ms (next.js: 1565ms, application-code: 99ms)
+ GET /breweries 200 in 61ms (next.js: 5ms, application-code: 56ms)
+⨯ upstream image response failed for https://images.unsplash.com/photo-1608270176050-12ec057de8d8?auto=format&fit=crop&q=80&w=800 404
+ GET /breweries/county/frederick 200 in 156ms (next.js: 21ms, application-code: 134ms)
+[browser] Image with src "https://images.unsplash.com/photo-1550345332-09e3ac987658?auto=format&fit=crop&q=80&w=800" was detected as the Largest Contentful Paint (LCP). Please add the `loading="eager"` property if this image is above the fold.
+Read more: https://nextjs.org/docs/app/api-reference/components/image#loading
+ GET /breweries/category/dog-friendly 200 in 1624ms (next.js: 1451ms, application-code: 173ms)
+ GET /breweries 200 in 180ms (next.js: 4ms, application-code: 176ms)
+⨯ upstream image response failed for https://images.unsplash.com/photo-1608270176050-12ec057de8d8?auto=format&fit=crop&q=80&w=800 404


### PR DESCRIPTION
Adds county and brewery-category discovery to Maryland Beer Atlas. Extends county and category dynamic landing pages with reliable count badges, region indicators, schema.org ItemList JSON-LD, and empty states. Updates the brewery directory with interactive county and category discovery grids, count indicators in filter dropdowns, and SEO-friendly crawlable links in the footer.

---
*PR created automatically by Jules for task [971187133209318960](https://jules.google.com/task/971187133209318960) started by @cfrome77*